### PR TITLE
Updated README to point users to alternate implementation

### DIFF
--- a/README
+++ b/README
@@ -87,6 +87,13 @@ the string. Other instances may occur where reading invalid JSON text does not c
 error to be generated. Malformed JSON Texts such as missing end " (quote) on strings or
 invalid number formats (1.2e6.3) will cause errors as such documents can not be read
  reliably.
+ 
+For those users who require an implementation of of the org.json libraries utilizing a 
+well-recognized open-source license (Apache ver. 2.0), a clean-room implemenation of the
+org.json API was performed and is now available at [https://github.com/openjson].
+This alternative version places the classes into the com.github.openjson package, which prevents 
+class conflicts with implementations utilizing the org.json libraries.
+
 
 Release history:
 20171018    Checkpoint for recent commits.


### PR DESCRIPTION
Many companies, organizations, and projects do not wish to use this project because of Doug Crockford's license.  An alternative clean-room implementation was written. However, that version (https://github.com/tdunning/open-json) used the same package name as this work.  That alternate version has created conflict when projects use this project as well as other projects that include the clean-room implementation.  This message will help steer individual to a fork of that project that has an appropriate package name.